### PR TITLE
🧼  Needed to include FormData types and lint fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@types/formdata": "^0.10.1",
         "@types/node": ">=10.0.0",
         "camelcase-keys": "^6.2.2",
         "form-data": "^3.0.1",
@@ -156,6 +157,11 @@
       "dependencies": {
         "dotenv": "*"
       }
+    },
+    "node_modules/@types/formdata": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@types/formdata/-/formdata-0.10.1.tgz",
+      "integrity": "sha512-9QqwrYucRiQu5XWsswEFkHzgDbHxWVec/ynfJwFr39D9llGygxQ7sqMP5ru6SCDFEqQYfZewMHvZLFJddKTPpg=="
     },
     "node_modules/@types/node": {
       "version": "15.3.0",
@@ -1999,6 +2005,11 @@
       "requires": {
         "dotenv": "*"
       }
+    },
+    "@types/formdata": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@types/formdata/-/formdata-0.10.1.tgz",
+      "integrity": "sha512-9QqwrYucRiQu5XWsswEFkHzgDbHxWVec/ynfJwFr39D9llGygxQ7sqMP5ru6SCDFEqQYfZewMHvZLFJddKTPpg=="
     },
     "@types/node": {
       "version": "15.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",
@@ -44,6 +44,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "@types/formdata": "^0.10.1",
     "@types/node": ">=10.0.0",
     "camelcase-keys": "^6.2.2",
     "form-data": "^3.0.1",

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -114,7 +114,7 @@ export class ContactApi {
     const body = contact
     const resp = await this.client.fire(
       'POST',
-      `contacts`,
+      'contacts',
       undefined,
       body)
     if (resp?.response?.status === 422) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch'
+import type { FormData } from '@types/formdata'
 import path from 'path'
 import camelCaseKeys from 'camelcase-keys'
 

--- a/src/letter.ts
+++ b/src/letter.ts
@@ -159,7 +159,7 @@ export class LetterApi {
     }
     const resp = await this.client.fire(
       'POST',
-      `letters`,
+      'letters',
       undefined,
       body)
     if (resp?.response?.status === 422) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -91,7 +91,7 @@ export class TemplateApi {
     const body = template
     const resp = await this.client.fire(
       'POST',
-      `templates`,
+      'templates',
       undefined,
       body)
     if (resp?.response?.status === 422) {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -79,7 +79,7 @@ export class WebhookApi {
   }> {
     const resp = await this.client.fire(
       'GET',
-      `webhooks`,
+      'webhooks',
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status === 404) {
@@ -141,7 +141,7 @@ export class WebhookApi {
     const body = webhook
     const resp = await this.client.fire(
       'POST',
-      `webhooks`,
+      'webhooks',
       undefined,
       body)
     if (resp?.response?.status === 422) {


### PR DESCRIPTION
We should have run lint before the first commit - but I forgot. This
puts the FormData types in the file for clean usage, and then there were
a few lint-inspired fixes in the code. Nothing major, but needed to be
clean.