### PR TITLE
🐛  We can't append nulls to FormData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",

--- a/src/bank-account.ts
+++ b/src/bank-account.ts
@@ -123,7 +123,9 @@ export class BankAccountApi {
           case 'metadata':
             if (typeof v === 'object') {
               Object.entries(v).forEach(([sk, sv]) => {
-                form.append(`${k}[${sk}]`, sv)
+                if (sv || sv === false || sv === 0 || sv === '') {
+                  form.append(`${k}[${sk}]`, sv)
+                }
               })
             } else {
               form.append(k, v.toString())

--- a/src/check.ts
+++ b/src/check.ts
@@ -130,7 +130,9 @@ export class CheckApi {
           case 'metadata':
             if (typeof v === 'object') {
               Object.entries(v).forEach(([sk, sv]) => {
-                form.append(`${k}[${sk}]`, sv)
+                if (sv || sv === false || sv === 0 || sv === '') {
+                  form.append(`${k}[${sk}]`, sv)
+                }
               })
             } else {
               form.append(k, v.toString())

--- a/src/letter.ts
+++ b/src/letter.ts
@@ -132,7 +132,9 @@ export class LetterApi {
             case 'metadata':
               if (typeof v === 'object') {
                 Object.entries(v).forEach(([sk, sv]) => {
-                  form.append(`${k}[${sk}]`, sv)
+                  if (sv || sv === false || sv === 0 || sv === '') {
+                    form.append(`${k}[${sk}]`, sv)
+                  }
                 })
               } else {
                 form.append(k, v.toString())

--- a/src/postcard.ts
+++ b/src/postcard.ts
@@ -122,7 +122,9 @@ export class PostcardApi {
             case 'metadata':
               if (typeof v === 'object') {
                 Object.entries(v).forEach(([sk, sv]) => {
-                  form.append(`${k}[${sk}]`, sv)
+                  if (sv || sv === false || sv === 0 || sv === '') {
+                    form.append(`${k}[${sk}]`, sv)
+                  }
                 })
               } else {
                 form.append(k, v.toString())


### PR DESCRIPTION
When we were adding in the sub-Objects to the FormData, we were not
doing the same level of checks that we did at the top level - and that
was allowing `null` values to attempt to be added to the FormData -
which was blowing up. These chagnes now filter out the `null` values for
the FormData - as they are meant to be "nothing" anyway.