### PR TITLE
📦  Added PostGrid Address Validation service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/formdata": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",

--- a/src/address.ts
+++ b/src/address.ts
@@ -1,0 +1,530 @@
+import path from 'path'
+import type { PostGrid, PostGridOptions, PostGridError } from './'
+
+export interface Address {
+  recipient?: string;
+  line1: string;
+  line2?: string;
+  city?: string;
+  provinceOrState?: string;
+  postalOrZip?: string;
+  zipPlus4?: string;
+  firmName?: string;
+  country?: string;
+  countryName?: string;
+  status?: string;
+}
+
+export interface LookupInfo {
+  used: number;
+  freeLimit: number;
+}
+
+export interface CityState {
+  city: string;
+  provinceOrState: string;
+  country?: string;
+}
+
+import { mkError } from './'
+
+export class AddressApi {
+  client: PostGrid;
+  baseRoute: string;
+
+  constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
+    this.client = client
+    this.baseRoute = 'v1/addver'
+  }
+
+  /*
+   * Function to ask the PostGrid Address Verification service what the counts
+   * are on the free lookups, and how many have been used to this point on this
+   * API Key. This is a simple call to get useful data to make sure things are
+   * working well.
+   */
+  async lookupInfo(): Promise<{
+    success: boolean,
+    info?: {
+      status: string;
+      message: string;
+      data: LookupInfo;
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'GET',
+      this.baseRoute,
+      { 'x-api-key': this.client.apiKeys.addr },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      info: resp.payload,
+    }
+  }
+
+  /*
+   * Function to take a freeform address of the form:
+   *
+   *   '3288 Tara Ln, Indianapolis, IN 46224'
+   *
+   * or a structured address of the form:
+   *
+   *   {
+   *     line1: '3288 Tara Ln',
+   *     city: 'Indianapolis',
+   *     postalOrZip: '46224',
+   *     provinceOrState: 'IN',
+   *   }
+   *
+   * and validate it with the service, and return the Address - if it validates.
+   */
+  async verify(address: string | Partial<Address>): Promise<{
+    success: boolean,
+    verified: boolean,
+    address?: {
+      status: string;
+      message: string;
+      data: Address;
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return {
+        success: false,
+        verified: false,
+        error: mkError('Missing PostGrid Address API Key!'),
+      }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'POST',
+      path.join(this.baseRoute, 'verifications'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      { properCase: true },
+      { address }
+    )
+    if (resp?.response?.status >= 400) {
+      return {
+        success: false,
+        verified: false,
+        error: resp?.payload?.error,
+      }
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      verified: (resp && ['verified', 'corrected'].includes(resp.payload?.data?.status)),
+      address: resp.payload,
+    }
+  }
+
+  /*
+   * Function to look for possible autocomplete matches for the provided
+   * street and country - defaulting to the 'US'. This will return something
+   * like:
+   *
+   *   {
+   *     success: true,
+   *     previews: {
+   *       status: 'success',
+   *       message: 'Retrieved verified address completions successfully.',
+   *       data: [
+   *         { line1: '77 N MAIN ST', city: undefined, provinceOrState: 'UT' },
+   *         { line1: '77 S MAIN ST', city: undefined, provinceOrState: 'UT' },
+   *         { line1: '77 N MAIN ST', city: undefined, provinceOrState: 'UT' },
+   *         { line1: '77 S MAIN ST', city: undefined, provinceOrState: 'UT' },
+   *         { line1: '77 E MAIN ST', city: undefined, provinceOrState: 'UT' },
+   *         { line1: '77 W MAIN ST', city: undefined, provinceOrState: 'UT' },
+   *         { line1: '77 N MAIN ST', city: 'ABERDEEN', provinceOrState: 'ID' },
+   *         { line1: '77 S MAIN ST', city: 'ABERDEEN', provinceOrState: 'ID' },
+   *         { line1: '77 N MAIN ST', city: 'ABERDEEN', provinceOrState: 'SD' },
+   *         { line1: '77 S MAIN ST', city: 'ABERDEEN', provinceOrState: 'SD' }
+   *       ]
+   *     }
+   *   }
+   *
+   * with the street argument of: '77 main st'.
+   */
+  async autocompletePreviews(street: string, country?: string): Promise<{
+    success: boolean,
+    previews?: {
+      status: string;
+      message: string;
+      data: Partial<Address>[];
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'GET',
+      path.join(this.baseRoute, 'completions'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      {
+        properCase: true,
+        partialStreet: street,
+        countryFilter: country || 'US',
+        provInsteadOfPC: true,
+      },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    // map the data to look like Address records for consistency...
+    if (Array.isArray(resp.payload.data)) {
+      resp.payload.data = resp.payload.data
+        .map((p: any) => p.preview)
+        .map((p: any) => {
+          return { line1: p.address, city: p.city, provinceOrState: p.prov }
+        })
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      previews: resp.payload,
+    }
+  }
+
+  /*
+   * Function to take something like an address preview, above:
+   *
+   *   {
+   *     line1: '77 N MAIN ST',
+   *     city: 'ABERDEEN',
+   *     provinceOrState: 'ID'
+   *   }
+   *
+   * and do the complete address validation and completion on it returning
+   * something like:
+   *
+   *   {
+   *     success: true,
+   *     previews: {
+   *       status: 'success',
+   *       message: 'Retrieved verified address completions successfully.',
+   *       data: [
+   *         {
+   *           line1: '77 S MAIN ST',
+   *           city: 'ABERDEEN',
+   *           provinceOrState: 'SD',
+   *           postalOrZip: '57401',
+   *           country: 'US'
+   *         }
+   *       ]
+   *     }
+   *   }
+   */
+  async autocompleteAddress(address: Partial<Address>): Promise<{
+    success: boolean,
+    addresses?: {
+      status: string;
+      message: string;
+      data: Address[];
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'POST',
+      path.join(this.baseRoute, 'completions'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      { properCase: true },
+      {
+        partialStreet: address.line1,
+        cityFilter: address.city,
+        stateFilter: address.provinceOrState,
+        pcFilter: address.postalOrZip,
+        countryFilter: address.country || 'US',
+      },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    // map the data to look like Address records for consistency...
+    if (Array.isArray(resp.payload.data)) {
+      resp.payload.data = resp.payload.data
+        .map((p: any) => p.address)
+        .map((p: any) => {
+          return {
+            line1: p.address,
+            city: p.city,
+            provinceOrState: p.prov,
+            postalOrZip: p.pc,
+            country: p.country,
+          }
+        })
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      addresses: resp.payload,
+    }
+  }
+
+  /*
+   * Function to take a batch of up to 2000 freeform or structured addresses
+   * and return each one verified - or not - and complete. The output will
+   * look something like this:
+   *
+   *   {
+   *     success: true,
+   *     addresses: {
+   *       status: 'success',
+   *       message: 'Verified address batch successfully.',
+   *       data: [
+   *         {
+   *           line1: '3288 Tara Ln',
+   *           city: 'Indianapolis',
+   *           postalOrZip: '46224',
+   *           provinceOrState: 'IN',
+   *           country: 'us',
+   *           countryName: 'UNITED STATES',
+   *           zipPlus4: '2231',
+   *           status: 'verified',
+   *           errors: {}
+   *         },
+   *         {
+   *           line1: '3000 Tara Ln  ',
+   *           city: 'Indianapolis',
+   *           postalOrZip: '46224',
+   *           provinceOrState: 'in',
+   *           status: 'failed',
+   *           errors: {}
+   *         },
+   *         {
+   *           line1: '77 S Main St',
+   *           city: 'Aberdeen',
+   *           postalOrZip: '57401',
+   *           provinceOrState: 'SD',
+   *           country: 'us',
+   *           countryName: 'UNITED STATES',
+   *           zipPlus4: '4218',
+   *           status: 'verified',
+   *           errors: {}
+   *         }
+   *       ]
+   *     }
+   *   }
+   */
+  async batchVerify(addresses: (string | Partial<Address>)[]): Promise<{
+    success: boolean,
+    addresses?: {
+      status: string;
+      message: string;
+      data: Address[];
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'POST',
+      path.join(this.baseRoute, 'verifications/batch'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      { properCase: true },
+      { addresses },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    // map the data to look like Address records for consistency...
+    if (Array.isArray(resp.payload.data.results)) {
+      resp.payload.data = resp.payload.data.results
+        .map((p: any) => p.verifiedAddress)
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      addresses: resp.payload,
+    }
+  }
+
+  /*
+   * Function to take a _guess_ at a freeform or structured address, and
+   * pull back all the suggestions for the correct address that could be
+   * returned. This will look at different parts of the address in order
+   * to "find" the actual address you're looking for. The result will be
+   * something like:
+   *
+   *   {
+   *     success: true,
+   *     addresses: {
+   *       status: 'success',
+   *       message: 'Address suggestions retrieved successfully.',
+   *       data: [
+   *         {
+   *           city: 'Aberdeen',
+   *           country: 'us',
+   *           countryName: 'UNITED STATES',
+   *           errors: {},
+   *           line1: '77 N Main St',
+   *           postalOrZip: '57401',
+   *           provinceOrState: 'SD',
+   *           status: 'verified',
+   *           zipPlus4: '3428'
+   *         },
+   *         {
+   *           city: 'Aberdeen',
+   *           country: 'us',
+   *           countryName: 'UNITED STATES',
+   *           errors: {},
+   *           line1: '77 S Main St',
+   *           postalOrZip: '57401',
+   *           provinceOrState: 'SD',
+   *           status: 'verified',
+   *           zipPlus4: '4218'
+   *         },
+   *         ...
+   *       },
+   *     ]
+   *   }
+   */
+  async suggestAddresses(address: string | Partial<Address>): Promise<{
+    success: boolean,
+    addresses?: {
+      status: string;
+      message: string;
+      data: any;
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'POST',
+      path.join(this.baseRoute, 'suggestions'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      { properCase: true },
+      { address },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      addresses: resp.payload,
+    }
+  }
+
+  /*
+   * Function to take a freeform address and parse it into all the components
+   * that PostGrid recognizes. If the address argument is:
+   *
+   *   '3288 Tara Ln, Indianapolis, IN 46224'
+   *
+   * then the result will be:
+   *
+   *   {
+   *     success: true,
+   *     address: {
+   *       status: 'success',
+   *       message: 'Success.',
+   *       data: {
+   *         city: 'indianapolis',
+   *         houseNumber: '3288',
+   *         postcode: '46224',
+   *         road: 'tara ln',
+   *         state: 'in'
+   *       }
+   *     }
+   *   }
+   */
+  async parseAddress(address: string): Promise<{
+    success: boolean,
+    address?: {
+      status: string;
+      message: string;
+      data: any;
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'POST',
+      path.join(this.baseRoute, 'parses'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      { properCase: true },
+      { address },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      address: resp.payload,
+    }
+  }
+
+  /*
+   * Function to take a freeform address and parse it into all the components
+   * that PostGrid recognizes. If the address argument is:
+   *
+   *   '60540'
+   *
+   * then the result will be:
+   *
+   *   {
+   *     success: true,
+   *     address: {
+   *       status: 'success',
+   *       message: 'Success.',
+   *       data: {
+   *         city: 'NAPERVILLE',
+   *         provinceOrState: 'IL'
+   *       }
+   *     }
+   *   }
+   */
+  async lookupCityState(postalCode: string): Promise<{
+    success: boolean,
+    address?: {
+      status: string;
+      message: string;
+      data: CityState;
+    },
+    error?: PostGridError,
+  }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.addr) {
+      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+    }
+    // ... now we can make the call...
+    const resp = await this.client.fire(
+      'POST',
+      path.join(this.baseRoute, 'city_states'),
+      { 'x-api-key': this.client.apiKeys.addr },
+      { properCase: true },
+      { postalOrZip: postalCode },
+    )
+    if (resp?.response?.status >= 400) {
+      return { success: false, error: resp?.payload?.error }
+    }
+    return {
+      success: (resp && !resp.payload?.error),
+      address: resp.payload,
+    }
+  }
+}

--- a/src/address.ts
+++ b/src/address.ts
@@ -26,7 +26,7 @@ export interface CityState {
   country?: string;
 }
 
-import { mkError } from './'
+import { NO_ADDR_API_KEY } from './'
 
 export class AddressApi {
   client: PostGrid;
@@ -54,7 +54,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -99,11 +99,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return {
-        success: false,
-        verified: false,
-        error: mkError('Missing PostGrid Address API Key!'),
-      }
+      return { ...NO_ADDR_API_KEY, verified: false }
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -165,7 +161,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -236,7 +232,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -331,7 +327,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -406,7 +402,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -459,7 +455,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(
@@ -509,7 +505,7 @@ export class AddressApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.addr) {
-      return { success: false, error: mkError('Missing PostGrid Address API Key!') }
+      return NO_ADDR_API_KEY
     }
     // ... now we can make the call...
     const resp = await this.client.fire(

--- a/src/bank-account.ts
+++ b/src/bank-account.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 
 export interface BankAccount {
@@ -33,9 +34,11 @@ import { mkError } from './'
 
 export class BankAccountApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -48,9 +51,15 @@ export class BankAccountApi {
     account?: BankAccount,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `bank_accounts/${id}`
+      path.join(this.baseRoute, 'bank_accounts', id),
+      { 'x-api-key': this.client.apiKeys.mail }
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -71,9 +80,15 @@ export class BankAccountApi {
     accounts?: BankAccountList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'bank_accounts',
+      path.join(this.baseRoute, 'bank_accounts'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -116,6 +131,11 @@ export class BankAccountApi {
     error?: PostGridError,
     message?: string,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const form = new FormData()
     for (const [k, v] of Object.entries(bankAccount)) {
       // only add in the entries that have a non-null or defined, value...
@@ -157,7 +177,8 @@ export class BankAccountApi {
     }
     const resp = await this.client.fire(
       'POST',
-      'bank_accounts',
+      path.join(this.baseRoute, 'bank_accounts'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       form)
     if (resp?.response?.status >= 400) {
@@ -179,9 +200,15 @@ export class BankAccountApi {
     account?: BankAccount,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `bank_accounts/${id}`
+      path.join(this.baseRoute, 'bank_accounts', id),
+      { 'x-api-key': this.client.apiKeys.mail }
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/src/bank-account.ts
+++ b/src/bank-account.ts
@@ -30,7 +30,7 @@ export interface BankAccountList {
 
 import fs from 'fs'
 import FormData from 'form-data'
-import { mkError } from './'
+import { mkError, NO_MAIL_API_KEY } from './'
 
 export class BankAccountApi {
   client: PostGrid;
@@ -53,7 +53,7 @@ export class BankAccountApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -82,7 +82,7 @@ export class BankAccountApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -133,7 +133,7 @@ export class BankAccountApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const form = new FormData()
@@ -202,7 +202,7 @@ export class BankAccountApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 import type { Contact } from './contact'
 
@@ -33,12 +34,15 @@ export interface CheckList {
 }
 
 import FormData from 'form-data'
+import { mkError } from './'
 
 export class CheckApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -51,9 +55,15 @@ export class CheckApi {
     check?: Check,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `cheques/${id}`
+      path.join(this.baseRoute, 'cheques', id),
+      { 'x-api-key': this.client.apiKeys.mail }
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -74,9 +84,15 @@ export class CheckApi {
     checks?: CheckList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'cheques',
+      path.join(this.baseRoute, 'cheques'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -119,6 +135,11 @@ export class CheckApi {
     error?: PostGridError,
     message?: string,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const form = new FormData()
     for (const [k, v] of Object.entries(check)) {
       // only add in the entries that have a non-null or defined, value...
@@ -156,7 +177,8 @@ export class CheckApi {
     }
     const resp = await this.client.fire(
       'POST',
-      'cheques',
+      path.join(this.baseRoute, 'cheques'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       form)
     if (resp?.response?.status >= 400) {
@@ -178,9 +200,15 @@ export class CheckApi {
     check?: Check,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'POST',
-      `cheques/${id}/progressions`,
+      path.join(this.baseRoute, 'cheques', id, 'progressions'),
+      { 'x-api-key': this.client.apiKeys.mail }
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -201,9 +229,15 @@ export class CheckApi {
     check?: Check,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `cheques/${id}`
+      path.join(this.baseRoute, 'cheques', id),
+      { 'x-api-key': this.client.apiKeys.mail }
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/src/check.ts
+++ b/src/check.ts
@@ -34,7 +34,7 @@ export interface CheckList {
 }
 
 import FormData from 'form-data'
-import { mkError } from './'
+import { NO_MAIL_API_KEY } from './'
 
 export class CheckApi {
   client: PostGrid;
@@ -57,7 +57,7 @@ export class CheckApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -86,7 +86,7 @@ export class CheckApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -137,7 +137,7 @@ export class CheckApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const form = new FormData()
@@ -202,7 +202,7 @@ export class CheckApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -231,7 +231,7 @@ export class CheckApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -30,7 +30,7 @@ export interface ContactList {
   data: Contact[];
 }
 
-import { mkError } from './'
+import { NO_MAIL_API_KEY } from './'
 
 export class ContactApi {
   client: PostGrid;
@@ -53,7 +53,7 @@ export class ContactApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -82,7 +82,7 @@ export class ContactApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -130,7 +130,7 @@ export class ContactApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const body = contact
@@ -161,7 +161,7 @@ export class ContactApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 
 export interface Contact {
@@ -29,11 +30,15 @@ export interface ContactList {
   data: Contact[];
 }
 
+import { mkError } from './'
+
 export class ContactApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -46,9 +51,15 @@ export class ContactApi {
     contact?: Contact,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `contacts/${id}`
+      path.join(this.baseRoute, 'contacts', id),
+      { 'x-api-key': this.client.apiKeys.mail }
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -69,9 +80,15 @@ export class ContactApi {
     contacts?: ContactList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'contacts',
+      path.join(this.baseRoute, 'contacts'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -111,10 +128,16 @@ export class ContactApi {
     contact?: Contact,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const body = contact
     const resp = await this.client.fire(
       'POST',
-      'contacts',
+      path.join(this.baseRoute, 'contacts'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -136,9 +159,15 @@ export class ContactApi {
     contact?: Contact,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `contacts/${id}`
+      path.join(this.baseRoute, 'contacts', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,3 +179,19 @@ export function mkError(message: string): PostGridError {
     message,
   }
 }
+
+/*
+ * Each function in each Api class needs to test and make sure that the
+ * Client has the appropriate API Key for PostGrid to do what it needs
+ * to do. So rather than duplicate that code and structure, we simply
+ * have it here, so each of the API Keys, and import it in each module.
+ */
+export const NO_ADDR_API_KEY = {
+  success: false,
+  error: mkError('Missing PostGrid Address API Key!'),
+}
+
+export const NO_MAIL_API_KEY = {
+  success: false,
+  error: mkError('Missing PostGrid Print-Mail API Key!'),
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,23 @@ import { PostcardApi } from './postcard'
 import { BankAccountApi } from './bank-account'
 import { CheckApi } from './check'
 import { WebhookApi } from './webhook'
+import { AddressApi } from './address'
 
 const ClientVersion = require('../package.json').version
 const PROTOCOL = 'https'
-const POSTGRID_HOST = 'api.postgrid.com/print-mail/v1/'
+const POSTGRID_HOST = 'api.postgrid.com'
+
+/*
+ * PostGrid has two different internal systems that have not - as yet - been
+ * brought together under one roof. So it's possible to have an API Key for
+ * just the print-mail part, or just the address part, or both. So we need
+ * to have a way to handle these two keys, and apply the right one at the
+ * right time.
+ */
+export interface PostGridApiKeys {
+  mail?: string;
+  addr?: string;
+}
 
 /*
  * These are the acceptable options to the creation of the Client:
@@ -27,7 +40,7 @@ const POSTGRID_HOST = 'api.postgrid.com/print-mail/v1/'
  */
 export interface PostGridOptions {
   host?: string;
-  apiKey?: string;
+  apiKeys: PostGridApiKeys;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookEvents?: string[];
@@ -51,7 +64,7 @@ export interface PostGridError {
  */
 export class PostGrid {
   host: string
-  apiKey: string
+  apiKeys: PostGridApiKeys
   webhookUrl?: string
   webhookSecret?: string
   webhookEvents?: string[]
@@ -62,10 +75,16 @@ export class PostGrid {
   bankAccount: BankAccountApi
   check: CheckApi
   webhook: WebhookApi
+  address: AddressApi
 
-  constructor (apiKey: string, options?: PostGridOptions) {
+  constructor (apiKeys: PostGridApiKeys | string, options?: PostGridOptions) {
     this.host = options?.host || POSTGRID_HOST
-    this.apiKey = apiKey
+    // see if we support the legacy usage of just the one Print-Mail key
+    if (typeof apiKeys === 'string') {
+      this.apiKeys = { mail: apiKeys }
+    } else {
+      this.apiKeys = apiKeys
+    }
     this.webhookUrl = options?.webhookUrl
     this.webhookSecret = options?.webhookSecret
     this.webhookEvents = options?.webhookEvents
@@ -77,6 +96,7 @@ export class PostGrid {
     this.bankAccount = new BankAccountApi(this, options)
     this.check = new CheckApi(this, options)
     this.webhook = new WebhookApi(this, options)
+    this.address = new AddressApi(this, options)
 
     // if we have a webhook, then create that now
     if (this.webhookUrl) {
@@ -97,7 +117,8 @@ export class PostGrid {
   async fire(
     method: string,
     uri: string,
-    query?: { [index:string] : number | string },
+    headers?: any,
+    query?: { [index:string] : number | string | boolean },
     body?: object | object[] | FormData,
   ): Promise<{ response: any, payload?: any }> {
     // build up the complete url from the provided 'uri' and the 'host'
@@ -108,11 +129,10 @@ export class PostGrid {
     }
     const isForm = isFormData(body)
     // make the appropriate headers
-    let headers = {
+    headers = { ...headers,
       Accept: 'application/json',
-      'x-api-key': this.apiKey,
       'X-PostGrid-Client-Ver': ClientVersion,
-    } as any
+    }
     if (!isForm) {
       headers = { ...headers, 'Content-Type': 'application/json' }
     }
@@ -121,6 +141,7 @@ export class PostGrid {
       method: method,
       body: isForm ? (body as any) : (body ? JSON.stringify(body) : undefined),
       headers,
+      redirect: 'follow',
     })
     try {
       const payload = camelCaseKeys((await response.json()), {deep: true})

--- a/src/letter.ts
+++ b/src/letter.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 import type { Contact } from './contact'
 
@@ -30,12 +31,15 @@ export interface LetterList {
 }
 
 import FormData from 'form-data'
+import { mkError } from './'
 
 export class LetterApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -48,9 +52,15 @@ export class LetterApi {
     letter?: Letter,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `letters/${id}`
+      path.join(this.baseRoute, 'letters', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -71,9 +81,15 @@ export class LetterApi {
     letters?: LetterList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'letters',
+      path.join(this.baseRoute, 'letters'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -115,6 +131,10 @@ export class LetterApi {
     error?: PostGridError,
     message?: string,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
     // set some reasonable defaults on the letter
     letter.color = letter.color || false
     letter.doubleSided = letter.doubleSided || false
@@ -161,7 +181,8 @@ export class LetterApi {
     }
     const resp = await this.client.fire(
       'POST',
-      'letters',
+      path.join(this.baseRoute, 'letters'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -183,9 +204,15 @@ export class LetterApi {
     letter?: Letter,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'POST',
-      `letters/${id}/progressions`,
+      path.join(this.baseRoute, 'letters', id, 'progressions'),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -206,9 +233,15 @@ export class LetterApi {
     letter?: Letter,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `letters/${id}`
+      path.join(this.baseRoute, 'letters', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/src/letter.ts
+++ b/src/letter.ts
@@ -31,7 +31,7 @@ export interface LetterList {
 }
 
 import FormData from 'form-data'
-import { mkError } from './'
+import { NO_MAIL_API_KEY } from './'
 
 export class LetterApi {
   client: PostGrid;
@@ -54,7 +54,7 @@ export class LetterApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -83,7 +83,7 @@ export class LetterApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -133,7 +133,7 @@ export class LetterApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // set some reasonable defaults on the letter
     letter.color = letter.color || false
@@ -206,7 +206,7 @@ export class LetterApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -235,7 +235,7 @@ export class LetterApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/postcard.ts
+++ b/src/postcard.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 import type { Contact } from './contact'
 
@@ -29,12 +30,15 @@ export interface PostcardList {
 }
 
 import FormData from 'form-data'
+import { mkError } from './'
 
 export class PostcardApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -47,9 +51,15 @@ export class PostcardApi {
     postcard?: Postcard,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `postcards/${id}`
+      path.join(this.baseRoute, 'postcards', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -70,9 +80,15 @@ export class PostcardApi {
     postcards?: PostcardList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'postcards',
+      path.join(this.baseRoute, 'postcards'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -109,6 +125,11 @@ export class PostcardApi {
     error?: PostGridError,
     message?: string,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     let body = postcard
     if (Buffer.isBuffer(postcard.pdf)) {
       const form = new FormData()
@@ -151,7 +172,8 @@ export class PostcardApi {
     }
     const resp = await this.client.fire(
       'POST',
-      'postcards',
+      path.join(this.baseRoute, 'postcards'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -173,9 +195,15 @@ export class PostcardApi {
     postcard?: Postcard,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'POST',
-      `postcards/${id}/progressions`,
+      path.join(this.baseRoute, 'postcards', id, 'progressions'),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -196,9 +224,15 @@ export class PostcardApi {
     postcard?: Postcard,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `postcards/${id}`
+      path.join(this.baseRoute, 'postcards', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/src/postcard.ts
+++ b/src/postcard.ts
@@ -30,7 +30,7 @@ export interface PostcardList {
 }
 
 import FormData from 'form-data'
-import { mkError } from './'
+import { NO_MAIL_API_KEY } from './'
 
 export class PostcardApi {
   client: PostGrid;
@@ -53,7 +53,7 @@ export class PostcardApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -82,7 +82,7 @@ export class PostcardApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -127,7 +127,7 @@ export class PostcardApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     let body = postcard
@@ -197,7 +197,7 @@ export class PostcardApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -226,7 +226,7 @@ export class PostcardApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 
 export interface Template {
@@ -17,11 +18,15 @@ export interface TemplateList {
   data: Template[];
 }
 
+import { mkError } from './'
+
 export class TemplateApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -34,9 +39,15 @@ export class TemplateApi {
     template?: Template,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `templates/${id}`
+      path.join(this.baseRoute, 'templates', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -57,9 +68,15 @@ export class TemplateApi {
     templates?: TemplateList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'templates',
+      path.join(this.baseRoute, 'templates'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -88,10 +105,16 @@ export class TemplateApi {
     template?: Template,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const body = template
     const resp = await this.client.fire(
       'POST',
-      'templates',
+      path.join(this.baseRoute, 'templates'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -118,10 +141,16 @@ export class TemplateApi {
     template?: Template,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const body = template
     const resp = await this.client.fire(
       'POST',
-      `templates/${id}`,
+      path.join(this.baseRoute, 'templates', id),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -143,9 +172,15 @@ export class TemplateApi {
     template?: Template,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `templates/${id}`
+      path.join(this.baseRoute, 'templates', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/src/template.ts
+++ b/src/template.ts
@@ -18,7 +18,7 @@ export interface TemplateList {
   data: Template[];
 }
 
-import { mkError } from './'
+import { NO_MAIL_API_KEY } from './'
 
 export class TemplateApi {
   client: PostGrid;
@@ -41,7 +41,7 @@ export class TemplateApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -70,7 +70,7 @@ export class TemplateApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -107,7 +107,7 @@ export class TemplateApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const body = template
@@ -143,7 +143,7 @@ export class TemplateApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const body = template
@@ -174,7 +174,7 @@ export class TemplateApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -38,7 +38,7 @@ export interface WebhookInvocationList {
   data: WebhookInvocation[];
 }
 
-import { mkError } from './'
+import { NO_MAIL_API_KEY } from './'
 
 export class WebhookApi {
   client: PostGrid;
@@ -61,7 +61,7 @@ export class WebhookApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -90,7 +90,7 @@ export class WebhookApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -123,7 +123,7 @@ export class WebhookApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(
@@ -163,7 +163,7 @@ export class WebhookApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const body = webhook
@@ -202,7 +202,7 @@ export class WebhookApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const body = webhook
@@ -233,7 +233,7 @@ export class WebhookApi {
   }> {
     // make sure we have the API Key for this call
     if (!this.client.apiKeys.mail) {
-      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+      return NO_MAIL_API_KEY
     }
     // ...and now we can make the call...
     const resp = await this.client.fire(

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import type { PostGrid, PostGridOptions, PostGridError } from './'
 
 export interface Webhook {
@@ -37,11 +38,15 @@ export interface WebhookInvocationList {
   data: WebhookInvocation[];
 }
 
+import { mkError } from './'
+
 export class WebhookApi {
   client: PostGrid;
+  baseRoute: string;
 
   constructor(client: PostGrid, options?: PostGridOptions) {  // eslint-disable-line no-unused-vars
     this.client = client
+    this.baseRoute = 'print-mail/v1/'
   }
 
   /*
@@ -54,9 +59,15 @@ export class WebhookApi {
     webhook?: Webhook,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `webhooks/${id}`
+      path.join(this.baseRoute, 'webhooks', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {
@@ -77,9 +88,15 @@ export class WebhookApi {
     webhooks?: WebhookList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      'webhooks',
+      path.join(this.baseRoute, 'webhooks'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -104,9 +121,15 @@ export class WebhookApi {
     invocations?: WebhookInvocationList,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'GET',
-      `webhooks/${id}/invocations`,
+      path.join(this.baseRoute, 'webhooks', id, 'invocations'),
+      { 'x-api-key': this.client.apiKeys.mail },
       { skip: skip || 0, limit: limit || 40 },
     )
     if (resp?.response?.status >= 400) {
@@ -138,10 +161,16 @@ export class WebhookApi {
     webhook?: Webhook,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const body = webhook
     const resp = await this.client.fire(
       'POST',
-      'webhooks',
+      path.join(this.baseRoute, 'webhooks'),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -171,10 +200,16 @@ export class WebhookApi {
     webhook?: Webhook,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const body = webhook
     const resp = await this.client.fire(
       'POST',
-      `webhooks/${id}`,
+      path.join(this.baseRoute, 'webhooks', id),
+      { 'x-api-key': this.client.apiKeys.mail },
       undefined,
       body)
     if (resp?.response?.status >= 400) {
@@ -196,9 +231,15 @@ export class WebhookApi {
     webhook?: Webhook,
     error?: PostGridError,
   }> {
+    // make sure we have the API Key for this call
+    if (!this.client.apiKeys.mail) {
+      return { success: false, error: mkError('Missing PostGrid Print-Mail API Key!') }
+    }
+    // ...and now we can make the call...
     const resp = await this.client.fire(
       'DELETE',
-      `webhooks/${id}`
+      path.join(this.baseRoute, 'webhooks', id),
+      { 'x-api-key': this.client.apiKeys.mail },
     )
     if (resp?.response?.status >= 400) {
       return {

--- a/tests/address.ts
+++ b/tests/address.ts
@@ -1,0 +1,130 @@
+import { PostGrid } from '../src/index'
+
+(async () => {
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
+
+  console.log('getting the lookup info...')
+  const one = await client.address.lookupInfo()
+  if (one.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Getting the lookup info failed, and the output is:')
+    console.log(one)
+  }
+
+  console.log('checking valid freeform address...')
+  const twoA = await client.address.verify('3288 Tara Ln, Indianapolis, IN 46224')
+  if (twoA.success && twoA.verified) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Validating the freeform address failed, and the output is:')
+    console.log(twoA)
+  }
+
+  console.log('checking valid structured address...')
+  const twoB = await client.address.verify({
+    line1: '3288 Tara Ln',
+    city: 'Indianapolis',
+    postalOrZip: '46224',
+    provinceOrState: 'IN',
+  })
+  if (twoB.success && twoB.verified) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Validating the structured address failed, and the output is:')
+    console.log(twoB)
+  }
+
+  console.log('checking invalid freeform address...')
+  const tre = await client.address.verify('3000 Tara Ln, Indianapolis, IN 46224')
+  if (tre.success && !tre.verified) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Validating the freeform address failed, and the output is:')
+    console.log(tre)
+  }
+
+  console.log('checking autocomplete previews...')
+  const fou = await client.address.autocompletePreviews('77 main st')
+  if (fou.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Getting autocomplete previews failed, and the output is:')
+    console.log(fou)
+  }
+
+  console.log('checking autocomplete an address...')
+  const fiv = await client.address.autocompleteAddress({
+    line1: '77 S MAIN ST',
+    city: 'ABERDEEN',
+    provinceOrState: 'SD',
+  })
+  if (fiv.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Getting autocomplete addresses failed, and the output is:')
+    console.log(fiv)
+  }
+
+  console.log('checking autocomplete an address...')
+  const six = await client.address.batchVerify([
+    '3288 Tara Ln, Indianapolis, IN 46224',
+    '3000 Tara Ln, Indianapolis, IN 46224',
+    {
+      line1: '77 S MAIN ST',
+      city: 'ABERDEEN',
+      provinceOrState: 'SD',
+      postalOrZip: '57401',
+    },
+  ])
+  if (six.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Getting batch verifications failed, and the output is:')
+    console.log(six)
+  }
+
+  console.log('checking structured suggest addresses...')
+  const sevA = await client.address.suggestAddresses({
+    line1: '77 MAIN ST',
+    city: 'ABERDEEN',
+    provinceOrState: 'SD',
+  })
+  if (sevA.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Getting suggested addresses failed, and the output is:')
+    console.log(sevA)
+  }
+
+  console.log('checking freeform suggest addresses...')
+  const sevB = await client.address.suggestAddresses('77 MAIN ST, ABERDEEN, SD')
+  if (sevB.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Getting suggested addresses failed, and the output is:')
+    console.log(sevB)
+  }
+
+  console.log('checking parsing address...')
+  const eig = await client.address.parseAddress('3288 Tara Ln, Indianapolis, IN 46224')
+  if (eig.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Parsing an address failed, and the output is:')
+    console.log(eig)
+  }
+
+  console.log('checking city/state lookup from postap code...')
+  const nin = await client.address.lookupCityState('60540')
+  if (nin.success) {
+    console.log('Success!')
+  } else {
+    console.log('Error! Lookup of City/State failed, and the output is:')
+    console.log(nin)
+  }
+
+})()

--- a/tests/bank-account.ts
+++ b/tests/bank-account.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Bank Account...')
   const who = {

--- a/tests/check.ts
+++ b/tests/check.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Check...')
   const what = {
@@ -36,7 +39,6 @@ import { PostGrid } from '../src/index'
   const one = await client.check.create(what)
   if (one.success) {
     console.log('Success!')
-    console.log(JSON.stringify(one, null, 2))
   } else {
     console.log('Error! Creating the check failed, and the output is:')
     console.log(one)
@@ -56,8 +58,7 @@ import { PostGrid } from '../src/index'
   console.log('listing the first page of 40 Checks...')
   const tre = await client.check.list()
   if (tre.success) {
-    console.log('Success!')
-    console.log(JSON.stringify(tre, null, 2))
+    console.log(`Success! The list contained ${tre.checks!.data!.length} checks...`)
   } else {
     console.log('Error! Listing the check failed, and the output is:')
     console.log(tre)

--- a/tests/contact.ts
+++ b/tests/contact.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Contact...')
   const who = {
@@ -38,7 +41,7 @@ import { PostGrid } from '../src/index'
   console.log('listing the first page of 40 Contacts...')
   const tre = await client.contact.list()
   if (tre.success) {
-    console.log('Success!')
+    console.log(`Success! The list contained ${tre.contacts!.data!.length} contacts...`)
   } else {
     console.log('Error! Listing the contact failed, and the output is:')
     console.log(tre)

--- a/tests/letter.ts
+++ b/tests/letter.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Letter...')
   const what = {
@@ -51,7 +54,7 @@ import { PostGrid } from '../src/index'
   console.log('listing the first page of 40 Letters...')
   const tre = await client.letter.list()
   if (tre.success) {
-    console.log('Success!')
+    console.log(`Success! ${tre.letters!.data!.length} letters in the list`)
   } else {
     console.log('Error! Listing the letters failed, and the output is:')
     console.log(tre)

--- a/tests/postcard.ts
+++ b/tests/postcard.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Postcard...')
   const what = {
@@ -53,7 +56,7 @@ import { PostGrid } from '../src/index'
   console.log('listing the first page of 40 Postcards...')
   const tre = await client.postcard.list()
   if (tre.success) {
-    console.log('Success!')
+    console.log(`Success! The list contained ${tre.postcards!.data!.length} postcards...`)
   } else {
     console.log('Error! Listing the postcards failed, and the output is:')
     console.log(tre)

--- a/tests/template.ts
+++ b/tests/template.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Template...')
   const what = {
@@ -30,7 +33,7 @@ import { PostGrid } from '../src/index'
   console.log('listing the first page of 40 Templates...')
   const tre = await client.template.list()
   if (tre.success) {
-    console.log('Success!')
+    console.log(`Success! The list contained ${tre.templates!.data!.length} templates...`)
   } else {
     console.log('Error! Listing the templates failed, and the output is:')
     console.log(tre)

--- a/tests/webhook.ts
+++ b/tests/webhook.ts
@@ -1,7 +1,10 @@
 import { PostGrid } from '../src/index'
 
 (async () => {
-  const client = new PostGrid(process.env.POSTGRID_API_KEY!)
+  const client = new PostGrid({
+    mail: process.env.POSTGRID_MAIL_API_KEY,
+    addr: process.env.POSTGRID_ADDR_API_KEY,
+  })
 
   console.log('creating a single Webhook...')
   const what = {
@@ -31,7 +34,7 @@ import { PostGrid } from '../src/index'
   console.log('listing the first page of 40 Webhooks...')
   const tre = await client.webhook.list()
   if (tre.success) {
-    console.log('Success!')
+    console.log(`Success! The list contained ${tre.webhooks!.data!.length} webhooks...`)
   } else {
     console.log('Error! Listing the webhooks failed, and the output is:')
     console.log(tre)
@@ -41,7 +44,7 @@ import { PostGrid } from '../src/index'
     console.log('listing the first page of 40 Webhook Invocations...')
     const tre = await client.webhook.invocations(one.webhook!.id)
     if (tre.success) {
-      console.log('Success!')
+      console.log(`Success! The list contained ${tre.invocations!.data!.length} invocations...`)
     } else {
       console.log('Error! Listing the webhooks failed, and the output is:')
       console.log(tre)


### PR DESCRIPTION
PostGrid has an Address Validation and Autocomplete service that the
client hadn't been created to handle - until now. These changes allow
for both services to be called from one client - with two different API
Keys - as would have to be the case based on PostGrid rules. The docs
are similar in that they show usage and output, but also link back to
the Address Verification docs where the endpoints are defined.