### PR TITLE
🔩  Previews now return PostalCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",

--- a/src/address.ts
+++ b/src/address.ts
@@ -134,16 +134,16 @@ export class AddressApi {
    *       status: 'success',
    *       message: 'Retrieved verified address completions successfully.',
    *       data: [
-   *         { line1: '77 N MAIN ST', city: undefined, provinceOrState: 'UT' },
-   *         { line1: '77 S MAIN ST', city: undefined, provinceOrState: 'UT' },
-   *         { line1: '77 N MAIN ST', city: undefined, provinceOrState: 'UT' },
-   *         { line1: '77 S MAIN ST', city: undefined, provinceOrState: 'UT' },
-   *         { line1: '77 E MAIN ST', city: undefined, provinceOrState: 'UT' },
-   *         { line1: '77 W MAIN ST', city: undefined, provinceOrState: 'UT' },
-   *         { line1: '77 N MAIN ST', city: 'ABERDEEN', provinceOrState: 'ID' },
-   *         { line1: '77 S MAIN ST', city: 'ABERDEEN', provinceOrState: 'ID' },
-   *         { line1: '77 N MAIN ST', city: 'ABERDEEN', provinceOrState: 'SD' },
-   *         { line1: '77 S MAIN ST', city: 'ABERDEEN', provinceOrState: 'SD' }
+   *         { line1: '77 N MAIN ST', city: undefined, postalOrZip: '84622' },
+   *         { line1: '77 S MAIN ST', city: undefined, postalOrZip: '84622' },
+   *         { line1: '77 N MAIN ST', city: undefined, postalOrZip: '84657' },
+   *         { line1: '77 S MAIN ST', city: undefined, postalOrZip: '84657' },
+   *         { line1: '77 E MAIN ST', city: undefined, postalOrZip: '84775' },
+   *         { line1: '77 W MAIN ST', city: undefined, postalOrZip: '84775' },
+   *         { line1: '77 N MAIN ST', city: 'ABERDEEN', postalOrZip: '83210' },
+   *         { line1: '77 S MAIN ST', city: 'ABERDEEN', postalOrZip: '83210' },
+   *         { line1: '77 N MAIN ST', city: 'ABERDEEN', postalOrZip: '57401' },
+   *         { line1: '77 S MAIN ST', city: 'ABERDEEN', postalOrZip: '57401' }
    *       ]
    *     }
    *   }
@@ -172,7 +172,7 @@ export class AddressApi {
         properCase: true,
         partialStreet: street,
         countryFilter: country || 'US',
-        provInsteadOfPC: true,
+        provInsteadOfPC: false,
       },
     )
     if (resp?.response?.status >= 400) {
@@ -183,7 +183,7 @@ export class AddressApi {
       resp.payload.data = resp.payload.data
         .map((p: any) => p.preview)
         .map((p: any) => {
-          return { line1: p.address, city: p.city, provinceOrState: p.prov }
+          return { line1: p.address, city: p.city, postalOrZip: p.pc }
         })
     }
     return {


### PR DESCRIPTION
The docs inticated that the output of the Address Previews was a
_truncated_ `postalOrZip`, but that's not the case... the complete
postal code is returned, and that's far more useful than the state of
province - as there's another function to get those from the postal
code. So we moved the client to pull the postal code. Yes, this could be
a parameter, or a state of the client, but we can add that later.