### PR TITLE
🐛  Add missing city on Contact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -8,6 +8,7 @@ export interface Contact {
   description?: string;
   addressLine1?: string;
   addressLine2?: string;
+  city?: string;
   provinceOrState?: string;
   postalOrZip?: string;
   country?: string;
@@ -112,6 +113,7 @@ export class ContactApi {
     description?: string;
     addressLine1?: string;
     addressLine2?: string;
+    city?: string;
     provinceOrState?: string;
     postalOrZip?: string;
     country?: string;

--- a/tests/contact.ts
+++ b/tests/contact.ts
@@ -9,6 +9,7 @@ import { PostGrid } from '../src/index'
   console.log('creating a single Contact...')
   const who = {
     addressLine1: '2929 Eagledale Dr',
+    city: 'Indianapolis',
     provinceOrState: 'IN',
     postalOrZip: '46224',
     countryCode: 'US',


### PR DESCRIPTION
We were missing the `city` on the Contact data because it waas/is
missing from the PostGrid docs, and that's what I based it off. In their
examples, they do have the `city`, and that's what I assumed they meant
to have in the docs, so now it's added and tested. Good.