### PR TITLE
🐛 Catch system-level thrown errors when fetch fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postgrid-node-client",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@types/formdata": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -50,7 +50,7 @@ export class WebhookApi {
   }
 
   /*
-   * Function to take a Webhook id and return the Wbhook object in the
+   * Function to take a Webhook id and return the Webhook object in the
    * response. If the webhook isn't in the system, then we will return
    * the appropriate error.
    */


### PR DESCRIPTION
Certain classes of system-level errors, like `ERR_SOCKET_CONNECTION_TIMEOUT`, were not handled when `fetch` was called.

This PR wraps the `fetch` call in the `fire` method with a `try`/`catch` that converts that system-level error into a response with a status of `503` and an error for displaying to users.