### PR TITLE
Adds express shipping type to checks, letters, and postcards

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -129,6 +129,7 @@ export class CheckApi {
     letterPDF?: Buffer | string;
     mergeVariables?: any;
     metadata?: any;
+    express?: boolean;
   }, options?: {
     idempotencyKey?: string;
   }): Promise<{

--- a/src/letter.ts
+++ b/src/letter.ts
@@ -125,6 +125,7 @@ export class LetterApi {
     pageCount?: number
     mergeVariables?: any;
     metadata?: any;
+    express?: boolean;
   }, options?: {
     idempotencyKey?: string;
   }): Promise<{

--- a/src/postcard.ts
+++ b/src/postcard.ts
@@ -119,6 +119,7 @@ export class PostcardApi {
     url?: string;
     mergeVariables?: any;
     metadata?: any;
+    express?: boolean;
   }, options?: {
     idempotencyKey?: string;
   }): Promise<{


### PR DESCRIPTION
Adds the `express` shipping boolean type to the `create()` methods of Letters, Checks, and Postcards.

https://docs.postgrid.com/#express-shipping