### PR TITLE
🔧 Add `extraService` to Create call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postgrid-node-client",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@types/formdata": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrid-node-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Node.js Client for PostGrid Business API",
   "keywords": [
     "postgrid.com",

--- a/src/letter.ts
+++ b/src/letter.ts
@@ -126,6 +126,7 @@ export class LetterApi {
     mergeVariables?: any;
     metadata?: any;
     express?: boolean;
+    extraService?: string;
   }, options?: {
     idempotencyKey?: string;
   }): Promise<{


### PR DESCRIPTION
Evidently, there is an `extraService` argument to the PostGrid Letter creation, and this then supports it for at least some folks. Glad to put it in.