### PR TITLE
Add support for attachedPDF form field

### DIFF
--- a/src/letter.ts
+++ b/src/letter.ts
@@ -127,6 +127,10 @@ export class LetterApi {
     metadata?: any;
     express?: boolean;
     extraService?: string;
+    attachedPDF?: {
+      placement: 'before_template' | 'after_template';
+      file: string | Buffer;
+    };
   }, options?: {
     idempotencyKey?: string;
   }): Promise<{
@@ -144,7 +148,7 @@ export class LetterApi {
     letter.doubleSided = letter.doubleSided || false
     letter.addressPlacement = letter.addressPlacement || 'insert_blank_page'
     let body = letter
-    if (Buffer.isBuffer(letter.pdf)) {
+    if (Buffer.isBuffer(letter.pdf) || letter.attachedPDF?.file) {
       const form = new FormData()
       for (const [k, v] of Object.entries(letter)) {
         // only add in the entries that have a non-null or defined, value...
@@ -162,6 +166,16 @@ export class LetterApi {
                 })
               } else {
                 form.append(k, v.toString())
+              }
+              break
+            case 'attachedPDF':
+              if (v.placement) {
+                form.append('attachedPDF[placement]', v.placement)
+              }
+              if (Buffer.isBuffer(v.file)) {
+                form.append('attachedPDF[file]', v.file, 'attachment.pdf')
+              } else {
+                form.append('attachedPDF[file]', v.file)
               }
               break
             case 'pdf':

--- a/tests/letter.ts
+++ b/tests/letter.ts
@@ -9,7 +9,7 @@ import { PostGrid } from '../src/index'
   console.log('creating a single Letter...')
   const what = {
     description: 'Cool new letter',
-    pdf: 'https://www.icnaam.org/documents/8x11singlesample.pdf',
+    pdf: 'https://icnaam.org/wp-content/uploads/2024/10/AIP-CP-2017-Troubleshooting.pdf',
     to: {
       firstName: 'Steve',
       lastName: 'Smith',


### PR DESCRIPTION
The Create Letter API supports `attachedPDF`, but this was not present in the node client. This PR adds support.

I also changed the PDF link in the Letter API test - the existing document no longer exists.